### PR TITLE
Fix multiple rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,24 @@ Then configure the rules you want to use under the rules section.
 }
 ```
 
+> Multiple errors
+```json
+{
+    "rules": {
+        "ban/ban": [
+            "error",
+            {"name": "api", "message": "This function is deprecated, please use api.call()"},
+            {"name": ["*", "push"], "message": "Prefer use es6 spread like [...items, newItem]"},
+            {"name": "functionName", "message": "Prefer use functionName2"}
+        ]
+    }
+}
+```
+
+# Todo
+
+- [ ] Possibility to add `error`and `warning` at same time
+
 # Contributing
 
 Please feel free to submit, comment anything on this repo :)

--- a/lib/rules/ban.js
+++ b/lib/rules/ban.js
@@ -10,6 +10,64 @@ const OBJECT_TOKEN = 'Object';
 const ALL_OBJECTS = '*';
 const NO_OBJECT = '';
 
+const SIMPLE_BAN_RULE_SCHEMA = {
+    'type': 'object',
+    'properties': {
+        'name': {
+            'type': 'string'
+        },
+        'message': {
+            'type': 'string'
+        }
+    },
+    'additionalProperties': false,
+    'required': ['name'],
+};
+
+const COMPLEX_BAN_RULE_SCHEMA = {
+    'type': 'object',
+    'properties': {
+        'name': {
+            'type': 'array',
+            'items': [
+                { 'type': 'string' },
+                { 'type': 'string' }
+            ]
+        },
+        'message': {
+            'type': 'string'
+        }
+    },
+    'additionalProperties': false,
+    'required': ['name'],
+};
+
+const formalizeRule = rule => {
+    const isArray = Array.isArray(rule.name);
+    return isArray
+        ? rule
+        : Object.assign({
+            name: [NO_OBJECT, rule.name],
+            message: rule.message
+        }, {});
+};
+
+const formalizeRules = banRules => banRules.reduce((rules, rule) => {
+    const isArrayRule = Array.isArray(rule);
+
+    if (isArrayRule) {
+        return [
+            ...rules,
+            ...formalizeRules(rule),
+        ];
+    }
+
+    return [
+        ...rules,
+        formalizeRule(rule),
+    ];
+}, []);
+
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
@@ -18,60 +76,36 @@ module.exports = {
     meta: {
         docs: {
             description: 'Ban methods',
-            category: 'Fill me in',
+            category: 'Ban',
             recommended: false
         },
         fixable: null,  // or "code" or "whitespace"
-        schema: [
-            {
-                'anyOf': [
-                    {
-                        'type': 'object',
-                        'properties': {
-                            'name': {
-                                'type': 'string'
-                            },
-                            'message': {
-                                'type': 'string'
-                            }
-                        },
-                        'additionalProperties': false,
-                        'required': ['name'],
-                    },
-                    {
-                        'type': 'object',
-                        'properties': {
-                            'name': {
-                                'type': 'array',
-                                'items': [
-                                    { 'type': 'string' },
-                                    { 'type': 'string' }
-                                ]
-                            },
-                            'message': {
-                                'type': 'string'
-                            }
-                        },
-                        'additionalProperties': false,
-                        'required': ['name'],
-                    }
-                ]
-            }
-        ]
+        schema: {
+            'anyOf': [
+                SIMPLE_BAN_RULE_SCHEMA,
+                COMPLEX_BAN_RULE_SCHEMA,
+                {
+                    'type': 'array',
+                    'minLength': 1,
+                    'uniqueItems': true,
+                    'items': [
+                        {
+                            'anyOf': [
+                                COMPLEX_BAN_RULE_SCHEMA,
+                                SIMPLE_BAN_RULE_SCHEMA,
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
     },
 
     create: function(context) {
 
         const banRules = context.options || [];
-        const banRulesWidthFunctionDefinitions = banRules.map(rule => {
-            const isArray = Array.isArray(rule.name);
-            return isArray
-                ? rule
-                : Object.assign({
-                    name: [NO_OBJECT, rule.name],
-                    message: rule.message
-                }, {});
-        });
+
+        const banRulesWidthFunctionDefinitions = formalizeRules(banRules);
 
         //----------------------------------------------------------------------
         // Helpers

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-ban",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-ban",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Allows you to bannish some methods or functions.",
   "keywords": [
     "eslint",

--- a/tests/lib/rules/ban.js
+++ b/tests/lib/rules/ban.js
@@ -113,3 +113,48 @@ ruleTester.run('ban with configuration for method (example ban method `push`)', 
         }
     ]
 });
+
+const multipleRuleOptions = [
+    {'name': ['animals', 'push'], 'message': 'don\'t push on animals'},
+    {'name': ['birds', 'push'], 'message': 'don\'t push on birds'},
+    {'name': 'functionName', 'message': 'Prefer use functionName2'}
+];
+
+ruleTester.run('ban with multiple rules', rule, {
+    valid: [
+        {
+            code: 'cars.push("dogs");',
+            options: multipleRuleOptions,
+        }
+    ],
+    invalid: [
+        {
+            code: 'animals.push("dogs");',
+            errors: [{
+                message: 'don\'t push on animals'
+            }],
+            options: multipleRuleOptions
+        },
+        {
+            code: 'birds.push("dogs");',
+            errors: [{
+                message: 'don\'t push on birds'
+            }],
+            options: multipleRuleOptions
+        },
+        {
+            code: 'functionName("dogs");',
+            errors: [{
+                message: 'Prefer use functionName2'
+            }],
+            options: multipleRuleOptions
+        },
+        {
+            code: 'functionName("dogs");',
+            errors: [{
+                message: 'Prefer use functionName2'
+            }],
+            options: multipleRuleOptions
+        },
+    ]
+});


### PR DESCRIPTION
In order to fix #2 yet we can add multiple rules like this:

```json
{
    "rules": {
        "ban/ban": [
            "error",
            {"name": "api", "message": "This function is deprecated, please use api.call()"},
            {"name": ["*", "push"], "message": "Prefer use es6 spread like [...items, newItem]"},
            {"name": "functionName", "message": "Prefer use functionName2"}
        ]
    }
}
```